### PR TITLE
Bandwidth Y axis units fix

### DIFF
--- a/windows-exporter-dashboard.json
+++ b/windows-exporter-dashboard.json
@@ -1318,7 +1318,7 @@
       },
       "yaxes": [
         {
-          "format": "Bps",
+          "format": "short",
           "label": null,
           "logBase": 1,
           "max": null,


### PR DESCRIPTION
Check query and other dashboards and can verify that the units aren't Bytes/S, but only Bytes.